### PR TITLE
biscuit asm fixes

### DIFF
--- a/src/asm_pairwise.c
+++ b/src/asm_pairwise.c
@@ -121,9 +121,9 @@ int main_asm(int argc, char *argv[]) {
       memset(cross, 0, 25*sizeof(int));
     }
     
+    assert(strlen(in->fields[2]) == 1);
     assert(strlen(in->fields[3]) == 1);
-    assert(strlen(in->fields[4]) == 1);
-    unsigned char _snp = in->fields[3][0];
+    unsigned char _snp = in->fields[6][0];
     unsigned char _cg = in->fields[4][0];
     cross[nt256char_to_nt256int8_table[_snp]*5 +
           nt256char_to_nt256int8_table[_cg]]++;


### PR DESCRIPTION
I'll be damned if I'm 100% sure, but it seems that the assertion of unit width only applies to the epistate number (1 or 2) and the Waston/Crick strand (+/-), whereas cg and snp are fields 5 and 7 (4 and 6 in 0-based indexing) are the correct ones for that.  At least, I think that's what's supposed to happen here.  It does compile and run without issue, although with the epireads I feed it, no output is produced.